### PR TITLE
Use GOTPCRELX instead of PLT

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -139,14 +139,16 @@ let mem__imp s =
   let imp_s = get_imp_symbol s in
   mem64_rip QWORD (emit_symbol imp_s)
 
-let rel_plt s =
+let rel_sym s =
   if windows && !Clflags.dlcode then mem__imp s
   else
-    sym (if use_plt then emit_symbol s ^ "@PLT" else emit_symbol s)
+    if use_got
+    then mem64_rip QWORD (emit_symbol s ^ "@GOTPCREL")
+    else sym (emit_symbol s)
 
-let emit_call s = I.call (rel_plt s)
+let emit_call s = I.call (rel_sym s)
 
-let emit_jump s = I.jmp (rel_plt s)
+let emit_jump s = I.jmp (rel_sym s)
 
 let load_symbol_addr s arg =
   if !Clflags.dlcode then
@@ -926,8 +928,8 @@ let fundecl fundecl =
     || max_frame_size >= stack_threshold_size then begin
       let overflow = new_label () and ret = new_label () in
       let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
-      I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r10;
-      I.cmp (domain_field Domainstate.Domain_current_stack) r10;
+      I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r11;
+      I.cmp (domain_field Domainstate.Domain_current_stack) r11;
       I.jb (label overflow);
       def_label ret;
       Some (overflow, ret)
@@ -947,7 +949,7 @@ let fundecl fundecl =
       cfi_adjust_cfa_offset 8;
         (* measured in words *)
       emit_call "caml_call_realloc_stack";
-      I.pop r10; (* ignored *)
+      I.pop r11; (* ignored *)
       cfi_adjust_cfa_offset (-8);
       I.jmp (label ret)
     end

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -134,17 +134,9 @@ let phys_reg n =
 
 let rax = phys_reg 0
 let rdx = phys_reg 4
-let r10 = phys_reg 10
 let r11 = phys_reg 11
 let rbp = phys_reg 12
 let rxmm15 = phys_reg 115
-
-let destroyed_by_plt_stub =
-  if not X86_proc.use_plt then [| |] else [| r10; r11 |]
-
-let num_destroyed_by_plt_stub = Array.length destroyed_by_plt_stub
-
-let destroyed_by_plt_stub_set = Reg.set_of_array destroyed_by_plt_stub
 
 let stack_slot slot ty =
   Reg.at_location ty (Stack slot)
@@ -170,7 +162,6 @@ let calling_conventions first_int last_int first_float last_float
           loc.(i) <- stack_slot (make_stack !ofs) ty;
           ofs := !ofs + size_int
         end;
-        assert (not (Reg.Set.mem loc.(i) destroyed_by_plt_stub_set))
     | Float ->
         if !float <= last_float then begin
           loc.(i) <- phys_reg !float;
@@ -193,16 +184,16 @@ let outgoing ofs =
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
 let loc_arguments arg =
-  calling_conventions 0 9 100 109 outgoing (- size_domainstate_args) arg
+  calling_conventions 0 10 100 109 outgoing (- size_domainstate_args) arg
 let loc_parameters arg =
   let (loc, _ofs) =
-    calling_conventions 0 9 100 109 incoming (- size_domainstate_args) arg
+    calling_conventions 0 10 100 109 incoming (- size_domainstate_args) arg
   in loc
 let loc_results res =
   let (loc, _ofs) = calling_conventions 0 0 100 100 not_supported 0 res
   in loc
 
-let max_arguments_for_tailcalls = 10 (* in regs *) + 64 (* in domain state *)
+let max_arguments_for_tailcalls = 11 (* in regs *) + 64 (* in domain state *)
 
 (* C calling conventions under Unix:
      first integer args in rdi, rsi, rdx, rcx, r8, r9
@@ -299,10 +290,7 @@ let destroyed_at_c_call =
        108;109;110;111;112;113;114;115])
 
 let destroyed_at_alloc_or_poll =
-  if X86_proc.use_plt then
-    destroyed_by_plt_stub
-  else
-    [| r11 |]
+  [| r11 |]
 
 let destroyed_at_oper = function
     Iop(Icall_ind | Icall_imm _) ->
@@ -352,7 +340,7 @@ let max_register_pressure =
   | Iintop(Idiv | Imod) | Iintop_imm((Idiv | Imod), _) ->
       consumes ~int:2 ~float:0
   | Ialloc _ | Ipoll _ ->
-      consumes ~int:(1 + num_destroyed_by_plt_stub) ~float:0
+      consumes ~int:1 ~float:0
   | Iintop(Icomp _) | Iintop_imm((Icomp _), _) ->
       consumes ~int:1 ~float:0
   | Istore(Single, _, _) ->

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -240,7 +240,7 @@ let masm =
   | S_win64 -> true
   | _ -> false
 
-let use_plt =
+let use_got =
   match system with
   | S_macosx | S_mingw64 | S_cygwin | S_win64 -> false
   | _ -> !Clflags.dlcode

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -77,8 +77,8 @@ val system: system
 val masm: bool
 val windows:bool
 
-(** Whether calls need to go via the PLT. *)
-val use_plt : bool
+(** Whether calls need to go via the GOT. *)
+val use_got : bool
 
 (** Support for plumbing a binary code emitter *)
 


### PR DESCRIPTION
See, for example: https://github.com/rust-lang/rust/pull/54592

It also gives us back a register for function calls

For reference: https://github.com/ocaml/ocaml/pull/1304


Potential issue: https://github.com/oxcaml/oxcaml/pull/5165#issuecomment-3723456053